### PR TITLE
4 persistent queue

### DIFF
--- a/backend/src/main/java/com/yagatalk/config/ApplicationConfiguration.java
+++ b/backend/src/main/java/com/yagatalk/config/ApplicationConfiguration.java
@@ -2,12 +2,22 @@ package com.yagatalk.config;
 
 import com.yagatalk.openaiclient.OpenAiClient;
 import com.yagatalk.openaiclient.OpenAiConfig;
+import com.yagatalk.persisntentqueue.*;
+import com.yagatalk.persisntentqueue.interfaces.IPersistentQueue;
+import com.yagatalk.persisntentqueue.interfaces.ResponseTask;
+import com.yagatalk.persisntentqueue.interfaces.TaskHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
 @Configuration
+@EnableScheduling
 public class ApplicationConfiguration {
 
     @Bean
@@ -20,4 +30,32 @@ public class ApplicationConfiguration {
     OpenAiClient openAiClient(WebClient.Builder builder, OpenAiConfig config) {
         return new OpenAiClient(builder, config);
     }
+
+    @Bean
+    IPersistentQueue myPersistentQueue(TaskQueueRepository taskQueueRepository,
+                                       List<TaskHandler> listOfHandlers){
+        MyPersistentQueue myPersistentQueue = new MyPersistentQueue(taskQueueRepository);
+        listOfHandlers.forEach(handler -> {
+            Type type = ((ParameterizedType) handler.getClass()
+                    .getGenericInterfaces()[0])
+                    .getActualTypeArguments()[0];
+            if (type instanceof Class<?>) {
+                Class<?> taskType = (Class<?>) type;
+                if (GetAssistantResponseTask.class.isAssignableFrom(taskType)) {
+                    myPersistentQueue.registerHandler(taskType, handler);
+                }
+            }
+        });
+
+
+
+
+
+
+
+//        MyPersistentQueue myPersistentQueue = new MyPersistentQueue(taskQueueRepository);
+//        myPersistentQueue.registerHandler(GetAssistantResponseTask.class,getAssistantResponseTaskHandler);
+        return myPersistentQueue;
+    }
+
 }

--- a/backend/src/main/java/com/yagatalk/config/ApplicationConfiguration.java
+++ b/backend/src/main/java/com/yagatalk/config/ApplicationConfiguration.java
@@ -41,20 +41,10 @@ public class ApplicationConfiguration {
                     .getActualTypeArguments()[0];
             if (type instanceof Class<?>) {
                 Class<?> taskType = (Class<?>) type;
-                if (GetAssistantResponseTask.class.isAssignableFrom(taskType)) {
-                    myPersistentQueue.registerHandler(taskType, handler);
-                }
+                myPersistentQueue.registerHandler(taskType, handler);
             }
         });
 
-
-
-
-
-
-
-//        MyPersistentQueue myPersistentQueue = new MyPersistentQueue(taskQueueRepository);
-//        myPersistentQueue.registerHandler(GetAssistantResponseTask.class,getAssistantResponseTaskHandler);
         return myPersistentQueue;
     }
 

--- a/backend/src/main/java/com/yagatalk/controllers/SessionController.java
+++ b/backend/src/main/java/com/yagatalk/controllers/SessionController.java
@@ -3,10 +3,6 @@ package com.yagatalk.controllers;
 import com.yagatalk.domain.Message;
 import com.yagatalk.openaiclient.Role;
 import com.yagatalk.services.ChatSessionService;
-import com.yagatalk.utill.ErrorResponse;
-import com.yagatalk.utill.InvalidRequestException;
-import org.apache.catalina.connector.Request;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/GetAssistantResponseTask.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/GetAssistantResponseTask.java
@@ -1,0 +1,9 @@
+package com.yagatalk.persisntentqueue;
+
+import com.yagatalk.persisntentqueue.interfaces.ResponseTask;
+
+import java.util.UUID;
+
+public record GetAssistantResponseTask(UUID chatSessionId) implements ResponseTask {
+
+}

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/GetAssistantResponseTaskHandler.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/GetAssistantResponseTaskHandler.java
@@ -1,0 +1,51 @@
+package com.yagatalk.persisntentqueue;
+
+import com.yagatalk.domain.Message;
+import com.yagatalk.openaiclient.OpenAiClient;
+import com.yagatalk.openaiclient.OpenAiMessage;
+import com.yagatalk.openaiclient.Role;
+import com.yagatalk.repositories.MessageRepository;
+import com.yagatalk.utill.UUIDGenerator;
+import com.yagatalk.persisntentqueue.interfaces.TaskHandler;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+
+public class GetAssistantResponseTaskHandler implements TaskHandler<GetAssistantResponseTask> {
+
+    private final MessageRepository messageRepository;
+    private final OpenAiClient openAiClient;
+
+
+    public GetAssistantResponseTaskHandler(MessageRepository messageRepository, OpenAiClient openAiClient, TaskQueueRepository taskQueueRepository) {
+        this.messageRepository = messageRepository;
+        this.openAiClient = openAiClient;
+    }
+
+    @Override
+    public void execute(GetAssistantResponseTask task) {
+        if (!messageRepository.getLastMessage(task.chatSessionId()).getRole().equals(Role.ASSISTANT)) {
+            List<OpenAiMessage> messages = messageRepository.getAllMessagesByChatSessionId(task.chatSessionId())
+                    .map(this::convertToOpenAiMessage)
+                    .toList();
+
+
+            String text = openAiClient.getAssistantResponse(messages).message().content();
+            Message message = new Message(UUIDGenerator.generateUUID(),
+                    task.chatSessionId(),
+                    Role.ASSISTANT,
+                    Instant.now(),
+                    text);
+            if (!messageRepository.getLastMessage(task.chatSessionId()).getRole().equals(Role.ASSISTANT)) {
+                messageRepository.save(message);
+            }
+        }
+    }
+
+    private OpenAiMessage convertToOpenAiMessage(Message message) {
+        return new OpenAiMessage(message.getRole(), message.getContent());
+    }
+}

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/MyPersistentQueue.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/MyPersistentQueue.java
@@ -1,0 +1,63 @@
+package com.yagatalk.persisntentqueue;
+
+import com.yagatalk.persisntentqueue.interfaces.IPersistentQueue;
+import com.yagatalk.persisntentqueue.interfaces.ResponseTask;
+import com.yagatalk.persisntentqueue.interfaces.TaskHandler;
+import jakarta.annotation.PostConstruct;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class MyPersistentQueue implements IPersistentQueue {
+    private final Map<Class<?>, TaskHandler<?>> handlerMap;
+    private final TaskQueueRepository taskQueueRepository;
+
+    public MyPersistentQueue(TaskQueueRepository taskQueueRepository) {
+        this.taskQueueRepository = taskQueueRepository;
+        handlerMap = new HashMap<>();
+    }
+
+    @Override
+    public <T> void registerHandler(Class<? extends T> taskType, TaskHandler<T> handler) {
+        if (handlerMap.containsKey(taskType)) {
+            throw new IllegalArgumentException("Handler for task class already registered");
+        }
+        handlerMap.put(taskType, handler);
+    }
+
+    @Override
+    public void submit(Object task) {
+        Class<?> taskType = task.getClass();
+        TaskHandler<Object> handler = (TaskHandler<Object>) handlerMap.get(taskType);
+        if (handler == null) {
+            throw new IllegalArgumentException("No handler for task class");
+        }
+        TaskQueue taskQueue = new TaskQueue((ResponseTask) task);
+        taskQueueRepository.save(taskQueue);
+
+    }
+
+    @Scheduled(fixedDelay = 10000)
+    public void processTasks() {
+        ExecutorService executor = Executors.newCachedThreadPool();
+        executor.submit(() -> {
+            for (TaskQueue task : taskQueueRepository.getAllTasksByState(State.PENDING).toList()) {
+                taskQueueRepository.updateState(task.getId(), State.RUNNING);
+                Class<?> taskType = task.getTask().getClass();
+                TaskHandler<Object> handler = (TaskHandler<Object>) handlerMap.get(taskType);
+                handler.execute(task.getTask());
+                taskQueueRepository.updateState(task.getId(), State.FINISHED);
+            }
+        });
+        executor.shutdown();
+    }
+
+    @PostConstruct
+    public void changePendingStateToRunning() {
+        taskQueueRepository.updateAllStateToPending();
+    }
+
+}

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/State.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/State.java
@@ -1,0 +1,7 @@
+package com.yagatalk.persisntentqueue;
+
+public enum State {
+    PENDING,
+    RUNNING,
+    FINISHED
+}

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/TaskQueue.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/TaskQueue.java
@@ -1,0 +1,55 @@
+package com.yagatalk.persisntentqueue;
+
+import com.yagatalk.persisntentqueue.interfaces.ResponseTask;
+import com.yagatalk.utill.UUIDGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class TaskQueue {
+    private final UUID id;
+    private final TaskType taskType;
+    private final ResponseTask task;
+    private final State state;
+    private final Instant submittedAt;
+
+    public TaskQueue(UUID id, TaskType taskType, ResponseTask task, State state, Instant submittedAt) {
+        this.id = id;
+        this.taskType = taskType;
+        this.task = task;
+        this.state = state;
+        this.submittedAt = submittedAt;
+    }
+
+    public TaskQueue(ResponseTask task) {
+        this.id = UUIDGenerator.generateUUID();
+        this.taskType = TaskType.GET_ASSISTANT_RESPONSE_TASK;
+        this.task = task;
+        this.state = State.PENDING;
+        this.submittedAt = Instant.now();
+
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public TaskType getTaskType() {
+        return taskType;
+    }
+
+    public ResponseTask getTask() {
+        return task;
+    }
+
+    public State getState() {
+        return state;
+    }
+
+    public Instant getSubmittedAt() {
+        return submittedAt;
+    }
+}
+
+
+

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/TaskQueueRepository.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/TaskQueueRepository.java
@@ -1,0 +1,82 @@
+package com.yagatalk.persisntentqueue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yagatalk.persisntentqueue.interfaces.ResponseTask;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+
+import java.sql.Timestamp;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Repository
+public class TaskQueueRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public TaskQueueRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void save(TaskQueue taskQueue) {
+
+        jdbcTemplate.update("INSERT INTO task_queue values (?,?,?::jsonb,?,?)",
+                taskQueue.getId(),
+                taskQueue.getTaskType().toString(),
+                taskToJson(taskQueue.getTask()),
+                taskQueue.getState().toString(),
+                Timestamp.from(taskQueue.getSubmittedAt()));
+    }
+
+    private String taskToJson(ResponseTask task) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.writeValueAsString(task);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void delete(TaskQueue taskQueue) {
+        jdbcTemplate.update("DELETE FROM task_queue WHERE id = ?", taskQueue.getId());
+    }
+
+    public Stream<TaskQueue> getAllTasks() {
+        return jdbcTemplate.queryForStream("SELECT * FROM task_queue",
+                extractTaskQueue);
+    }
+
+    public Stream<TaskQueue> getAllTasksByState(State state) {
+        return jdbcTemplate.queryForStream("SELECT * FROM task_queue WHERE state = ?",
+                extractTaskQueue,
+                state.toString());
+    }
+
+    public void updateAllStateToPending() {
+        jdbcTemplate.update("UPDATE task_queue set state = 'PENDING' WHERE state = 'RUNNING'");
+    }
+
+    public void updateState(UUID id, State state) {
+        jdbcTemplate.update("UPDATE task_queue set state=? where id=?", state.toString(), id);
+    }
+
+    private static final RowMapper<TaskQueue> extractTaskQueue =
+            (rs, rn) -> new TaskQueue(UUID.fromString(
+                    rs.getString("id")),
+                    TaskType.valueOf(rs.getString("task_type")),
+                    jsonToTask(rs.getString("task")),
+                    State.valueOf(rs.getString("state")),
+                    rs.getTimestamp("submitted_at").toInstant()
+            );
+
+    private static ResponseTask jsonToTask(String taskJson) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(taskJson, GetAssistantResponseTask.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/TaskType.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/TaskType.java
@@ -1,0 +1,8 @@
+package com.yagatalk.persisntentqueue;
+
+
+
+public enum TaskType {
+    GET_ASSISTANT_RESPONSE_TASK
+}
+

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/interfaces/IPersistentQueue.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/interfaces/IPersistentQueue.java
@@ -1,0 +1,7 @@
+package com.yagatalk.persisntentqueue.interfaces;
+
+public interface IPersistentQueue {
+    <T> void registerHandler(Class<? extends T> taskType, TaskHandler<T> handler);
+
+    void submit(Object task);
+}

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/interfaces/ResponseTask.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/interfaces/ResponseTask.java
@@ -1,0 +1,5 @@
+package com.yagatalk.persisntentqueue.interfaces;
+
+public interface ResponseTask {
+
+}

--- a/backend/src/main/java/com/yagatalk/persisntentqueue/interfaces/TaskHandler.java
+++ b/backend/src/main/java/com/yagatalk/persisntentqueue/interfaces/TaskHandler.java
@@ -1,0 +1,5 @@
+package com.yagatalk.persisntentqueue.interfaces;
+
+public interface TaskHandler<T> {
+    void execute(T task);
+}

--- a/backend/src/main/java/com/yagatalk/repositories/MessageRepository.java
+++ b/backend/src/main/java/com/yagatalk/repositories/MessageRepository.java
@@ -21,16 +21,29 @@ public class MessageRepository {
     }
 
     public Stream<Message> getAllMessagesByChatSessionId(UUID chatSessionId) {
-
-        return jdbcTemplate.queryForStream("SELECT * FROM message where chat_session_id=?",
+        return jdbcTemplate.queryForStream("SELECT * FROM message where chat_session_id=? ORDER BY created_time",
                 extractMessage,
                 chatSessionId);
     }
 
     public Stream<Message> getAllMessagesByChatSessionIdAfterMs(UUID chatSessionId, long ms) {
-        return jdbcTemplate.queryForStream("SELECT * FROM message WHERE chat_session_id = ? AND EXTRACT(EPOCH FROM created_time) * 1000 > ?;",
+
+        return jdbcTemplate.queryForStream("SELECT * FROM message WHERE chat_session_id = ? " +
+                        "AND EXTRACT(EPOCH FROM created_time) * 1000 > ? " +
+                        "ORDER BY created_time;",
                 extractMessage,
                 chatSessionId,ms);
+
+    }
+
+    public Message getLastMessage(UUID chatSessionId) {
+        return jdbcTemplate.queryForObject("SELECT *" +
+                        "FROM message " +
+                        "WHERE chat_session_id = ? " +
+                        "ORDER BY created_time DESC " +
+                        "LIMIT 1;",
+                extractMessage,
+                chatSessionId);
     }
 
     public void save(Message message) {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.driverClassName=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://localhost:5433/yaga-talk
 spring.datasource.username=admin
 spring.datasource.password=admin
+spring.datasource.hikari.maximum-pool-size=500
 
 logging.level.org.springframework.web=debug
 

--- a/backend/src/main/resources/db/migration/V20230701.1__сreate_tables.sql
+++ b/backend/src/main/resources/db/migration/V20230701.1__сreate_tables.sql
@@ -15,3 +15,12 @@ CREATE TABLE message (
     created_time timestamp with time zone not null,
     content varchar not null
 );
+
+CREATE TABLE task_queue (
+    id uuid primary key,
+    task_type text not null,
+    task jsonb not null,
+    state varchar not null,
+    submitted_at timestamp with time zone not null
+);
+

--- a/backend/src/test/java/com/yagatalk/YagaTalkApplicationTests.java
+++ b/backend/src/test/java/com/yagatalk/YagaTalkApplicationTests.java
@@ -8,6 +8,7 @@ class YagaTalkApplicationTests {
 
 	@Test
 	void contextLoads() {
+
 	}
 
 }


### PR DESCRIPTION
Моменты, вызывающие у меня сомнение:
1.  Так как мы пытыаемся сделать persistent queue максимально абстрактным, то я принял решение, что в классе, который TaskQueue поле, котороый task ( в таблице тип jsonb) будет интерфейсом ResponseTask. Просто сначала оно у меня было GetAssistnantResponseTask, потом String, в конечном итоге пришел к такому варианту.
2. В классе с конфигурацией создаю бин, MyPersistentQueue, который принимает именно список хендлеров, соотвественно, в методе, который регистрирует хендлеры нужно указывать аргумент <T>, который принимат один из хендлеров. Сделал это через рефлексию, если честно сам не понял как, но вроде работает. Конечно, на данном этапе возможно нужно было передавать просто один хендлер, но я раз ты говорил, и раз мы делаем все максимально абстрактным решил сделать пока так.
3. Возникли проблемы с HicariCp, я так понимаю, его тоже нужно потом будет нормально сконфигурировать, но пока сделал максимальный pool-size 500, тоже пока не вдавался сильно вподробности, как это работает.
4. Ещё одной интересной, даже неожиданной подставой для меня оказалось, что в messageRepo, в методе, который возвращает все сообщения пришлось добавить сортировку по времени, почему-то думал, что и без принудительной сортировки будет в правильной последовательности возвращать сообщения, но оказалось, что не всегда и из-за этого баги всякие бывают.
5. Было множество разных багов, из-за которых как-то не корректно работала система, вроде на данном этапе, все какие заметил пофиксил, остался ещё один в который я случайно как-то попал: 
Сейчас у нас такое, что: 
          1. Если последнее сообщение от ассистента, не делаем запрос в OpenAI
          2. Делаем запрос в OpenAI
          3. Если последнее сообщение от ассистента, то игнорируем ответ
Например: отправилось два сообщения от USERa так, что в таблице сообщений они идут последовательно. Но ответ на первый пришел быстрее, в итоге ответ на второй по факту игнорируется..
